### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Drizzle tutorial with React Hooks
 
-![drizzle_logo](https://github.com/trufflesuite/drizzle/raw/master/readme/drizzle-logomark.png?raw=true)
+<img src="https://truffleframework.com/img/drizzle-logomark.svg" alt="drizzle_logo" title="drizzle_logo" width="100" />
 
 I created a complete **React Hooks** version of this [**Drizzle tutorial**](https://www.trufflesuite.com/tutorials/getting-started-with-drizzle-and-react).
 
@@ -12,7 +12,7 @@ See the ReactJS [guidance on using hooks](https://reactjs.org/docs/hooks-referen
 
 ## To get this box ##
 
-1. Create a new directory. 
+1. Create a new directory.
 
 2. In the new directory, run ```truffle unbox atkinsonholly/Drizzle-tutorial-with-React-Hooks```. This should pull the box contents to the new local directory.
 


### PR DESCRIPTION
* Removed a trailing character that was rendering strangely on Truffle's box listing.
* Changed the Drizzle logo url--it moved because we switched to a monorepo.